### PR TITLE
Stop leaking the BLE connection when there is an exception reading device state.

### DIFF
--- a/airthings_ble/parser.py
+++ b/airthings_ble/parser.py
@@ -468,12 +468,12 @@ class AirthingsBluetoothDeviceData:
 
     async def update_device(self, ble_device: BLEDevice) -> AirthingsDevice:
         """Connects to the device through BLE and retrieves relevant data"""
-        client = await establish_connection(BleakClient, ble_device, ble_device.address)
-
         device = AirthingsDevice()
-
-        device = await self._get_device_characteristics(client, device)
-        device = await self._get_service_characteristics(client, device)
-        await client.disconnect()
+        client = await establish_connection(BleakClient, ble_device, ble_device.address)
+        try:
+            device = await self._get_device_characteristics(client, device)
+            device = await self._get_service_characteristics(client, device)
+        finally:
+            await client.disconnect()
 
         return device


### PR DESCRIPTION
Currently, `client.disconnect()` is not called if the library raises an exception when reading device state.