### PR TITLE
Update the notification receiver to wait until the full message is received before returning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ pip-delete-this-directory.txt
 
 # Misc
 .vscode
+.idea


### PR DESCRIPTION
When the MTU of the BLE connection is less than the size of the notification message (30 bytes in this case), an Airthings Wave+ (and possibly other models, but I don't have them to verify) will send the message over multiple packets. This PR teaches the code to wait for the full message.

See https://github.com/esphome/issues/issues/3951#issuecomment-1381636682 for full write up of the problem.

Addresses https://github.com/home-assistant/core/issues/85413.

This PR adapts the safety checks in https://github.com/vincegio/airthings-ble/pull/6 and supersedes it.