### PR TITLE
Fix "Characteristics not handled" warning

### DIFF
--- a/airthings_ble/parser.py
+++ b/airthings_ble/parser.py
@@ -425,7 +425,7 @@ class AirthingsBluetoothDeviceData:
                 continue
             if characteristic.name == "manufacturer":
                 device.manufacturer = data.decode(characteristic.format)
-            if characteristic.name == "hardware_rev":
+            elif characteristic.name == "hardware_rev":
                 device.hw_version = data.decode(characteristic.format)
             elif characteristic.name == "firmware_rev":
                 device.sw_version = data.decode(characteristic.format)


### PR DESCRIPTION
When I refactored the code in [this PR](https://github.com/vincegio/airthings-ble/pull/10/files?diff=unified&w=0#diff-bcbe2e7a152f0183952c47ea1e8dc4184e3e2a4f3541b269172de0feeb2619a6L383), I never changed `if` to an `elif`. This causes the code to print `Characteristics not handled: 00002a29-0000-1000-8000-00805f9b34fb` ([here](https://github.com/vincegio/airthings-ble/pull/19/files#diff-bcbe2e7a152f0183952c47ea1e8dc4184e3e2a4f3541b269172de0feeb2619a6L440-L442)) every time it fetches the manufacturer characteristic.