### PR TITLE
Add VOC and CO2 string sensors

### DIFF
--- a/airthings_ble/const.py
+++ b/airthings_ble/const.py
@@ -45,6 +45,18 @@ RADON_LOW = (50, 99, "low")
 RADON_MODERATE = (100, 299, "moderate")
 RADON_HIGH = (300, None, "high")
 
+"""
+0 - 249 ppb
+The VOC contents in the air are low.
+250 - 1999 ppb
+Look for VOC sources if this average level persists for a month
+2000 ppb and up
+The VOC contents are very high - consider taking action/ventilating right now
+"""
+VOC_LOW = (0, 249, "low")
+VOC_MODERATE = (250, 1999, "moderate")
+VOC_VERY_HIGH = (2000, None, "very high")
+
 BQ_TO_PCI_MULTIPLIER = 0.027
 
 CO2_MAX = 65534

--- a/airthings_ble/const.py
+++ b/airthings_ble/const.py
@@ -40,10 +40,10 @@ contact a professional radon mitigator.
 Keep measuring. If levels are maintained for more than 1 month,
 contact a professional radon mitigator.
 """
-VERY_LOW = (0, 49, "very low")
-LOW = (50, 99, "low")
-MODERATE = (100, 299, "moderate")
-HIGH = (300, None, "high")
+RADON_VERY_LOW = (0, 49, "very low")
+RADON_LOW = (50, 99, "low")
+RADON_MODERATE = (100, 299, "moderate")
+RADON_HIGH = (300, None, "high")
 
 BQ_TO_PCI_MULTIPLIER = 0.027
 

--- a/airthings_ble/const.py
+++ b/airthings_ble/const.py
@@ -57,6 +57,30 @@ VOC_LOW = (0, 249, "low")
 VOC_MODERATE = (250, 1999, "moderate")
 VOC_VERY_HIGH = (2000, None, "very high")
 
+"""
+250 - 399 ppm
+Normal background concentration in outdoor ambient air
+400 - 999 ppm
+Concentrations typical of occupied indoor spaces with good air exchange.
+1000 - 1999 ppm
+Complaints of drowsiness and poor air
+2000 - 4999 ppm
+Headaches, sleepiness and stagnant, stale, stuffy air. Poor concentration, loss
+of attention, increased heart rate and slight nausea.
+5000 - 39999 ppm
+Extremely high
+40000 and up
+Exposure may lead to serious oxygen deprivation resulting in permanent brain
+damage, coma and even death.
+"""
+CO2_LOW = (0, 249, "low")
+CO2_OUTDOOR_NORMAL = (250, 399, "outdoor normal")
+CO2_INDOOR_NORMAL = (400, 999, "indoor normal")
+CO2_HIGH = (1000, 1999, "high")
+CO2_VERY_HIGH = (2000, 4999, "very high")
+CO2_EXTREMELLY_HIGH = (5000, 39999, "extremelly high")
+CO2_CRITICAL = (40000, None, "critical")
+
 BQ_TO_PCI_MULTIPLIER = 0.027
 
 CO2_MAX = 65534

--- a/airthings_ble/parser.py
+++ b/airthings_ble/parser.py
@@ -40,15 +40,15 @@ from .const import (
     COMMAND_UUID_WAVE_2,
     COMMAND_UUID_WAVE_MINI,
     COMMAND_UUID_WAVE_PLUS,
-    HIGH,
-    LOW,
-    MODERATE,
     PERCENTAGE_MAX,
     PRESSURE_MAX,
+    RADON_HIGH,
+    RADON_LOW,
     RADON_MAX,
+    RADON_MODERATE,
+    RADON_VERY_LOW,
     TEMPERATURE_MAX,
     UPDATE_TIMEOUT,
-    VERY_LOW,
     VOC_MAX,
 )
 from .device_type import AirthingsDeviceType
@@ -379,14 +379,14 @@ class _NotificationReceiver:
 
 def get_radon_level(data: float) -> str:
     """Returns the applicable radon level"""
-    if data <= VERY_LOW[1]:
-        radon_level = VERY_LOW[2]
-    elif data <= LOW[1]:
-        radon_level = LOW[2]
-    elif data <= MODERATE[1]:
-        radon_level = MODERATE[2]
+    if data <= RADON_VERY_LOW[1]:
+        radon_level = RADON_VERY_LOW[2]
+    elif data <= RADON_LOW[1]:
+        radon_level = RADON_LOW[2]
+    elif data <= RADON_MODERATE[1]:
+        radon_level = RADON_MODERATE[2]
     else:
-        radon_level = HIGH[2]
+        radon_level = RADON_HIGH[2]
     return radon_level
 
 

--- a/airthings_ble/parser.py
+++ b/airthings_ble/parser.py
@@ -36,7 +36,14 @@ from .const import (
     CHAR_UUID_WAVE_2_DATA,
     CHAR_UUID_WAVE_PLUS_DATA,
     CHAR_UUID_WAVEMINI_DATA,
+    CO2_CRITICAL,
+    CO2_EXTREMELLY_HIGH,
+    CO2_HIGH,
+    CO2_INDOOR_NORMAL,
+    CO2_LOW,
     CO2_MAX,
+    CO2_OUTDOOR_NORMAL,
+    CO2_VERY_HIGH,
     COMMAND_UUID_WAVE_2,
     COMMAND_UUID_WAVE_MINI,
     COMMAND_UUID_WAVE_PLUS,
@@ -402,6 +409,24 @@ def get_voc_level(data: float) -> str:
         voc_level = VOC_VERY_HIGH[2]
     return voc_level
 
+def get_co2_level(data: float) -> str:
+    """Returns the applicable co2 level"""
+    if data <= CO2_LOW[1]:
+        co2_level = CO2_LOW[2]
+    elif data <= CO2_OUTDOOR_NORMAL[1]:
+        co2_level = CO2_OUTDOOR_NORMAL[2]
+    elif data <= CO2_INDOOR_NORMAL[1]:
+        co2_level = CO2_INDOOR_NORMAL[2]
+    elif data <= CO2_HIGH[1]:
+        co2_level = CO2_HIGH[2]
+    elif data <= CO2_VERY_HIGH[1]:
+        co2_level = CO2_VERY_HIGH[2]
+    elif data <= CO2_EXTREMELLY_HIGH[1]:
+        co2_level = CO2_EXTREMELLY_HIGH[2]
+    else:
+        co2_level = CO2_CRITICAL[2]
+    return co2_level
+
 sensor_decoders: dict[
     str,
     Callable[[bytearray], dict[str, float | None | str]],
@@ -627,6 +652,9 @@ class AirthingsBluetoothDeviceData:
 
                     if (d := sensor_data.get("voc")) is not None:
                         sensors["voc_level"] = get_voc_level(float(d))
+
+                    if (d := sensor_data.get("co2")) is not None:
+                        sensors["co2_level"] = get_co2_level(float(d))
 
                 if uuid_str in command_decoders:
                     decoder = command_decoders[uuid_str]

--- a/airthings_ble/parser.py
+++ b/airthings_ble/parser.py
@@ -49,7 +49,10 @@ from .const import (
     RADON_VERY_LOW,
     TEMPERATURE_MAX,
     UPDATE_TIMEOUT,
+    VOC_LOW,
     VOC_MAX,
+    VOC_MODERATE,
+    VOC_VERY_HIGH,
 )
 from .device_type import AirthingsDeviceType
 
@@ -389,6 +392,15 @@ def get_radon_level(data: float) -> str:
         radon_level = RADON_HIGH[2]
     return radon_level
 
+def get_voc_level(data: float) -> str:
+    """Returns the applicable voc level"""
+    if data <= VOC_LOW[1]:
+        voc_level = VOC_LOW[2]
+    elif data <= VOC_MODERATE[1]:
+        voc_level = VOC_MODERATE[2]
+    else:
+        voc_level = VOC_VERY_HIGH[2]
+    return voc_level
 
 sensor_decoders: dict[
     str,
@@ -612,6 +624,9 @@ class AirthingsBluetoothDeviceData:
                             sensors["radon_longterm_avg"] = (
                                 float(d) * BQ_TO_PCI_MULTIPLIER
                             )
+
+                    if (d := sensor_data.get("voc")) is not None:
+                        sensors["voc_level"] = get_voc_level(float(d))
 
                 if uuid_str in command_decoders:
                     decoder = command_decoders[uuid_str]


### PR DESCRIPTION
It is very convenient to have the radon sensors that translate the numeric value into a string ("very low", "low", etc.). As an user, I not necessarily know what are reasonable ranges for the measurements and having these strings makes it easy to know at a glance if I should take action or not.

This is true for VOC and CO2 as well, but the library (and HA) do not have string states for them, only the numeric values. So this PR adds two new sensors (for devices that support it), which are string states for VOC and CO2. The ranges were obtained directly from the Airthings website ([CO2](https://www.airthings.com/en-ca/contaminants/what-is-carbon-dioxide), [VOC](https://www.airthings.com/en-ca/contaminants/what-is-voc)). I copied them almost verbatim, except for the CO2 ranges 0-249 and 5000-39999, which are missing from the Airthings website (I just extrapolate to names that seemed reasonable). I want to make clear that this PR is not my personal endorsement for these ranges, I know nothing about what constitutes good and bad VOC and CO2 levels.

Also, I did not test the part that goes through `_get_service_characteristics()`, as the pytests do not go through that function, I just followed what is done for the radon levels. If the maintainers can easily check that this is correct, that would be great.

If this gets approved and merged, then I will work in the HA part to expose these them as new entities.