### PR TITLE
Add advertisement data parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ pip-delete-this-directory.txt
 # Misc
 .vscode
 .idea
+.DS_Store
 
 # Tests
 .coverage

--- a/airthings_ble/__init__.py
+++ b/airthings_ble/__init__.py
@@ -10,10 +10,10 @@ from .advertisement import (
 from .const import AIRTHINGS_SERVICE_UUIDS, AIRTHINGS_SHARED_SERVICE_UUID
 from .connectivity_mode import AirthingsConnectivityMode
 from .device_type import AirthingsDeviceType
+from .errors import UnknownDeviceError, UnsupportedDeviceError
 from .parser import (
     AirthingsBluetoothDeviceData,
     AirthingsDevice,
-    UnsupportedDeviceError,
 )
 
 __version__ = "1.2.0"
@@ -26,6 +26,7 @@ __all__ = [
     "AirthingsConnectivityMode",
     "AirthingsDevice",
     "AirthingsDeviceType",
+    "UnknownDeviceError",
     "UnsupportedDeviceError",
     "extract_serial_number_from_manufacturer_data",
     "parse_advertisement_data",

--- a/airthings_ble/__init__.py
+++ b/airthings_ble/__init__.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from .advertisement import (
+    AirthingsAdvertisementData,
+    extract_serial_number_from_manufacturer_data,
+    parse_advertisement_data,
+)
+from .const import AIRTHINGS_SERVICE_UUIDS, AIRTHINGS_SHARED_SERVICE_UUID
 from .connectivity_mode import AirthingsConnectivityMode
 from .device_type import AirthingsDeviceType
 from .parser import (
@@ -13,9 +19,14 @@ from .parser import (
 __version__ = "1.2.0"
 
 __all__ = [
+    "AIRTHINGS_SERVICE_UUIDS",
+    "AIRTHINGS_SHARED_SERVICE_UUID",
+    "AirthingsAdvertisementData",
     "AirthingsBluetoothDeviceData",
     "AirthingsConnectivityMode",
     "AirthingsDevice",
     "AirthingsDeviceType",
     "UnsupportedDeviceError",
+    "extract_serial_number_from_manufacturer_data",
+    "parse_advertisement_data",
 ]

--- a/airthings_ble/advertisement.py
+++ b/airthings_ble/advertisement.py
@@ -1,0 +1,102 @@
+"""Passive parsing helpers for Airthings BLE advertisements."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .const import (
+    AIRTHINGS_SHARED_SERVICE_UUID,
+    AIRTHINGS_UNIQUE_SERVICE_UUID_TO_MODEL,
+)
+from .device_type import AirthingsDeviceType
+
+_SUPPORTED_SERIAL_PREFIX_TO_MODEL: dict[str, AirthingsDeviceType] = {
+    AirthingsDeviceType.WAVE_GEN_1.value: AirthingsDeviceType.WAVE_GEN_1,
+    AirthingsDeviceType.WAVE_MINI.value: AirthingsDeviceType.WAVE_MINI,
+    AirthingsDeviceType.WAVE_PLUS.value: AirthingsDeviceType.WAVE_PLUS,
+    AirthingsDeviceType.WAVE_RADON.value: AirthingsDeviceType.WAVE_RADON,
+    AirthingsDeviceType.WAVE_ENHANCE_EU.value: AirthingsDeviceType.WAVE_ENHANCE_EU,
+    AirthingsDeviceType.WAVE_ENHANCE_US.value: AirthingsDeviceType.WAVE_ENHANCE_US,
+    AirthingsDeviceType.CORENTIUM_HOME_2.value: AirthingsDeviceType.CORENTIUM_HOME_2,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class AirthingsAdvertisementData:
+    """Parsed information available from an Airthings BLE advertisement."""
+
+    model: AirthingsDeviceType | None = None
+    serial_number: str | None = None
+    known_unsupported: bool = False
+
+
+def extract_serial_number_from_manufacturer_data(
+    manufacturer_data: bytes | bytearray | None,
+) -> str | None:
+    """Extract the full serial number from manufacturer data when available."""
+    if manufacturer_data is None or len(manufacturer_data) < 6:
+        return None
+    return str(int.from_bytes(manufacturer_data[2:6], "little"))
+
+
+def _model_from_service_uuids(
+    service_uuids: Iterable[str] | None,
+) -> AirthingsDeviceType | None:
+    """Resolve models that can be identified from unique service UUIDs."""
+    if service_uuids is None:
+        return None
+
+    resolved_models = {
+        AIRTHINGS_UNIQUE_SERVICE_UUID_TO_MODEL[service_uuid.lower()]
+        for service_uuid in service_uuids
+        if service_uuid.lower() in AIRTHINGS_UNIQUE_SERVICE_UUID_TO_MODEL
+    }
+    if len(resolved_models) != 1:
+        return None
+    return resolved_models.pop()
+
+
+def _has_shared_service_uuid(service_uuids: Iterable[str] | None) -> bool:
+    """Return if the advertisement uses the shared newer Airthings UUID."""
+    if service_uuids is None:
+        return False
+    return any(
+        service_uuid.lower() == AIRTHINGS_SHARED_SERVICE_UUID
+        for service_uuid in service_uuids
+    )
+
+
+def parse_advertisement_data(
+    local_name: str | None,
+    manufacturer_data: bytes | bytearray | None,
+    service_uuids: Iterable[str] | None = None,
+) -> AirthingsAdvertisementData | None:
+    """Parse advertisement data without connecting to the device."""
+    serial_number = extract_serial_number_from_manufacturer_data(manufacturer_data)
+    if serial_number is not None:
+        serial_prefix = serial_number[:4]
+        if serial_prefix in _SUPPORTED_SERIAL_PREFIX_TO_MODEL:
+            return AirthingsAdvertisementData(
+                model=_SUPPORTED_SERIAL_PREFIX_TO_MODEL[serial_prefix],
+                serial_number=serial_number,
+            )
+        if _has_shared_service_uuid(service_uuids):
+            return AirthingsAdvertisementData(
+                serial_number=serial_number,
+                known_unsupported=True,
+            )
+
+    if local_name and ("Renew" in local_name or "View" in local_name):
+        return AirthingsAdvertisementData(
+            serial_number=serial_number,
+            known_unsupported=True,
+        )
+
+    if model := _model_from_service_uuids(service_uuids):
+        return AirthingsAdvertisementData(model=model, serial_number=serial_number)
+
+    if serial_number is None:
+        return None
+
+    return AirthingsAdvertisementData(serial_number=serial_number)

--- a/airthings_ble/advertisement.py
+++ b/airthings_ble/advertisement.py
@@ -11,14 +11,12 @@ from .const import (
 )
 from .device_type import AirthingsDeviceType
 
-_SUPPORTED_SERIAL_PREFIX_TO_MODEL: dict[str, AirthingsDeviceType] = {
-    AirthingsDeviceType.WAVE_GEN_1.value: AirthingsDeviceType.WAVE_GEN_1,
-    AirthingsDeviceType.WAVE_MINI.value: AirthingsDeviceType.WAVE_MINI,
-    AirthingsDeviceType.WAVE_PLUS.value: AirthingsDeviceType.WAVE_PLUS,
-    AirthingsDeviceType.WAVE_RADON.value: AirthingsDeviceType.WAVE_RADON,
-    AirthingsDeviceType.WAVE_ENHANCE_EU.value: AirthingsDeviceType.WAVE_ENHANCE_EU,
-    AirthingsDeviceType.WAVE_ENHANCE_US.value: AirthingsDeviceType.WAVE_ENHANCE_US,
-    AirthingsDeviceType.CORENTIUM_HOME_2.value: AirthingsDeviceType.CORENTIUM_HOME_2,
+_KNOWN_UNSUPPORTED_MODEL_CODES: dict[str, str] = {
+    "2810": "Hub",
+    "2960": "View Plus",
+    "2980": "View Pollution",
+    "2989": "View Radon",
+    "4100": "Renew",
 }
 
 
@@ -28,16 +26,23 @@ class AirthingsAdvertisementData:
 
     model: AirthingsDeviceType | None = None
     serial_number: str | None = None
+    model_code: str | None = None
+    unsupported_name: str | None = None
     known_unsupported: bool = False
+
+    @property
+    def unknown(self) -> bool:
+        """Return if the advertisement looks Airthings, but is not classified."""
+        return self.model is None and not self.known_unsupported
 
 
 def extract_serial_number_from_manufacturer_data(
     manufacturer_data: bytes | bytearray | None,
 ) -> str | None:
     """Extract the full serial number from manufacturer data when available."""
-    if manufacturer_data is None or len(manufacturer_data) < 6:
+    if manufacturer_data is None or len(manufacturer_data) < 4:
         return None
-    return str(int.from_bytes(manufacturer_data[2:6], "little"))
+    return str(int.from_bytes(manufacturer_data[0:4], "little"))
 
 
 def _model_from_service_uuids(
@@ -67,36 +72,92 @@ def _has_shared_service_uuid(service_uuids: Iterable[str] | None) -> bool:
     )
 
 
+def _looks_like_airthings_serial_number(serial_number: str) -> bool:
+    """Return if the parsed value looks like a real Airthings serial number."""
+    return len(serial_number) == 10 and serial_number[0] in {"2", "3", "4"}
+
+
+def _normalize_serial_number(
+    manufacturer_data: bytes | bytearray | None,
+) -> str | None:
+    """Extract a plausible Airthings serial number from manufacturer data."""
+    serial_number = extract_serial_number_from_manufacturer_data(manufacturer_data)
+    if serial_number is None:
+        return None
+    if not _looks_like_airthings_serial_number(serial_number):
+        return None
+    return serial_number
+
+
+def _model_code_from_serial_number(serial_number: str | None) -> str | None:
+    """Extract a 4-digit Airthings model code from a normalized serial number."""
+    if serial_number is None or len(serial_number) < 4:
+        return None
+    return serial_number[:4]
+
+
+def _has_known_unsupported_name(local_name: str | None) -> bool:
+    """Return if the local name identifies a known unsupported family."""
+    return bool(local_name) and ("Renew" in local_name or "View" in local_name)
+
+
+def _is_known_unsupported_serial_number(serial_number: str) -> bool:
+    """Return if the serial number belongs to a known unsupported family."""
+    model_code = _model_code_from_serial_number(serial_number)
+    return model_code in _KNOWN_UNSUPPORTED_MODEL_CODES if model_code else False
+
+
+def _unsupported_name_from_model_code(model_code: str | None) -> str | None:
+    """Return the known unsupported family name for a model code."""
+    if model_code is None:
+        return None
+    return _KNOWN_UNSUPPORTED_MODEL_CODES.get(model_code)
+
+
 def parse_advertisement_data(
     local_name: str | None,
     manufacturer_data: bytes | bytearray | None,
     service_uuids: Iterable[str] | None = None,
 ) -> AirthingsAdvertisementData | None:
     """Parse advertisement data without connecting to the device."""
-    serial_number = extract_serial_number_from_manufacturer_data(manufacturer_data)
+    serial_number = _normalize_serial_number(manufacturer_data)
+    model_code = _model_code_from_serial_number(serial_number)
     if serial_number is not None:
-        serial_prefix = serial_number[:4]
-        if serial_prefix in _SUPPORTED_SERIAL_PREFIX_TO_MODEL:
+        if model := AirthingsDeviceType.from_model_code(model_code or ""):
             return AirthingsAdvertisementData(
-                model=_SUPPORTED_SERIAL_PREFIX_TO_MODEL[serial_prefix],
+                model=model,
                 serial_number=serial_number,
+                model_code=model_code,
             )
-        if _has_shared_service_uuid(service_uuids):
+        if _has_shared_service_uuid(service_uuids) and _is_known_unsupported_serial_number(
+            serial_number
+        ):
             return AirthingsAdvertisementData(
                 serial_number=serial_number,
+                model_code=model_code,
+                unsupported_name=_unsupported_name_from_model_code(model_code),
                 known_unsupported=True,
             )
 
-    if local_name and ("Renew" in local_name or "View" in local_name):
+    if _has_known_unsupported_name(local_name):
         return AirthingsAdvertisementData(
             serial_number=serial_number,
+            model_code=model_code,
+            unsupported_name=local_name,
             known_unsupported=True,
         )
 
     if model := _model_from_service_uuids(service_uuids):
-        return AirthingsAdvertisementData(model=model, serial_number=serial_number)
+        return AirthingsAdvertisementData(
+            model=model,
+            serial_number=serial_number,
+            model_code=model_code,
+        )
 
     if serial_number is None:
         return None
 
-    return AirthingsAdvertisementData(serial_number=serial_number)
+    return AirthingsAdvertisementData(
+        serial_number=serial_number,
+        model_code=model_code,
+    )

--- a/airthings_ble/const.py
+++ b/airthings_ble/const.py
@@ -1,6 +1,8 @@
-"""Constants for Airthings BLE parser"""
+"""Constants for Airthings BLE parser."""
 
 from uuid import UUID
+
+from .device_type import AirthingsDeviceType
 
 MFCT_ID = 820
 
@@ -79,3 +81,16 @@ RADON_MONTH_LEVEL = "radon_month_level"
 RADON_YEAR_AVG = "radon_year_avg"
 RADON_YEAR_LEVEL = "radon_year_level"
 VOC = "voc"
+
+
+AIRTHINGS_UNIQUE_SERVICE_UUID_TO_MODEL: dict[str, AirthingsDeviceType] = {
+    "b42e1f6e-ade7-11e4-89d3-123b93f75cba": AirthingsDeviceType.WAVE_GEN_1,
+    "b42e1c08-ade7-11e4-89d3-123b93f75cba": AirthingsDeviceType.WAVE_PLUS,
+    "b42e3882-ade7-11e4-89d3-123b93f75cba": AirthingsDeviceType.WAVE_MINI,
+    "b42e4a8e-ade7-11e4-89d3-123b93f75cba": AirthingsDeviceType.WAVE_RADON,
+}
+AIRTHINGS_SHARED_SERVICE_UUID = "b42e90a2-ade7-11e4-89d3-123b93f75cba"
+AIRTHINGS_SERVICE_UUIDS: tuple[str, ...] = (
+    *AIRTHINGS_UNIQUE_SERVICE_UUID_TO_MODEL,
+    AIRTHINGS_SHARED_SERVICE_UUID,
+)

--- a/airthings_ble/device_type.py
+++ b/airthings_ble/device_type.py
@@ -8,7 +8,6 @@ from airthings_ble.airthings_firmware import AirthingsFirmwareVersion
 class AirthingsDeviceType(Enum):
     """Airthings device types."""
 
-    UNKNOWN = "0"
     WAVE_GEN_1 = "2900"
     WAVE_MINI = "2920"
     WAVE_PLUS = "2930"
@@ -16,14 +15,6 @@ class AirthingsDeviceType(Enum):
     WAVE_ENHANCE_EU = "3210"
     WAVE_ENHANCE_US = "3220"
     CORENTIUM_HOME_2 = "3250"
-
-    raw_value: str  # pylint: disable=invalid-name
-
-    def __new__(cls, value: str) -> "AirthingsDeviceType":
-        """Create new device type."""
-        obj = object.__new__(cls)
-        obj.raw_value = value
-        return obj
 
     @classmethod
     def atom_devices(cls) -> list["AirthingsDeviceType"]:
@@ -35,15 +26,20 @@ class AirthingsDeviceType(Enum):
         ]
 
     @classmethod
-    def from_raw_value(cls, value: str) -> "AirthingsDeviceType":
-        """Get device type from raw value."""
+    def from_model_code(cls, value: str) -> "AirthingsDeviceType | None":
+        """Resolve a supported model from an exact Airthings model code."""
         for device_type in cls:
             if device_type.value == value:
-                device_type.raw_value = value
                 return device_type
-        unknown_device = AirthingsDeviceType.UNKNOWN
-        unknown_device.raw_value = value
-        return unknown_device
+        return None
+
+    @classmethod
+    def from_serial_number(cls, serial_number: str) -> "AirthingsDeviceType | None":
+        """Resolve a supported model from an Airthings serial number."""
+        if len(serial_number) < 4:
+            return None
+        model_code = serial_number[:4]
+        return cls.from_model_code(model_code)
 
     @property
     # pylint: disable=too-many-return-statements
@@ -64,7 +60,7 @@ class AirthingsDeviceType(Enum):
             return "Wave Enhance"
         if self == AirthingsDeviceType.CORENTIUM_HOME_2:
             return "Corentium Home 2"
-        return "Unknown"
+        raise ValueError(f"Unhandled device type: {self}")
 
     def battery_percentage(self, voltage: float) -> int:
         """Calculate battery percentage based on voltage."""

--- a/airthings_ble/errors.py
+++ b/airthings_ble/errors.py
@@ -1,0 +1,9 @@
+"""Library exceptions for airthings_ble."""
+
+
+class UnsupportedDeviceError(Exception):
+    """Unsupported Airthings device."""
+
+
+class UnknownDeviceError(Exception):
+    """Unknown Airthings device."""

--- a/airthings_ble/parser.py
+++ b/airthings_ble/parser.py
@@ -78,6 +78,7 @@ from .const import (
     VOC,
 )
 from .device_type import AirthingsDeviceType
+from .errors import UnknownDeviceError, UnsupportedDeviceError
 
 Characteristic = namedtuple("Characteristic", ["uuid", "name", "format"])
 
@@ -115,10 +116,6 @@ class DisconnectedError(Exception):
     """Disconnected from device."""
 
 
-class UnsupportedDeviceError(Exception):
-    """Unsupported device."""
-
-
 def short_address(address: str) -> str:
     """Convert a Bluetooth address to a short address."""
     return address.replace("-", "").replace(":", "")[-6:].upper()
@@ -134,7 +131,8 @@ class AirthingsDeviceInfo:
     manufacturer: str = ""
     hw_version: str = ""
     sw_version: str = ""
-    model: AirthingsDeviceType = AirthingsDeviceType.UNKNOWN
+    model: AirthingsDeviceType | None = None
+    model_code: str = ""
     name: str = ""
     identifier: str = ""
     address: str = ""
@@ -142,7 +140,8 @@ class AirthingsDeviceInfo:
 
     def friendly_name(self) -> str:
         """Generate a name for the device."""
-
+        if self.model is None:
+            return "Airthings"
         return f"Airthings {self.model.product_name}"
 
 
@@ -158,7 +157,8 @@ class AirthingsDevice(AirthingsDeviceInfo):
 
     def friendly_name(self) -> str:
         """Generate a name for the device."""
-
+        if self.model is None:
+            return "Airthings"
         return f"Airthings {self.model.product_name}"
 
 
@@ -201,14 +201,17 @@ class AirthingsBluetoothDeviceData:
                 self.logger.debug("Get device characteristics exception: %s", err)
                 return
 
-            device_info.model = AirthingsDeviceType.from_raw_value(data.decode("utf-8"))
-            if device_info.model == AirthingsDeviceType.UNKNOWN:
-                raise UnsupportedDeviceError(
-                    f"Model {data.decode('utf-8')} is not supported"
+            device_info.model_code = data.decode("utf-8")
+            device_info.model = AirthingsDeviceType.from_model_code(
+                device_info.model_code
+            )
+            if device_info.model is None:
+                raise UnknownDeviceError(
+                    f"Unknown Airthings model {device_info.model_code} at {client.address}"
                 )
 
         characteristics = _CHARS_BY_MODELS.get(
-            device_info.model.raw_value, device_info_characteristics
+            device_info.model_code, device_info_characteristics
         )
 
         self.logger.debug("Fetching device info characteristics: %s", characteristics)
@@ -257,7 +260,7 @@ class AirthingsBluetoothDeviceData:
         if not device_info.name:
             device_info.name = device_info.friendly_name()
 
-        if device_info.model:
+        if device_info.model is not None:
             device_info.did_first_sync = True
 
         # Copy the cached device_info to device

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -18,6 +18,12 @@ def test_extract_serial_number_from_manufacturer_data() -> None:
         == "2930123456"
     )
     assert extract_serial_number_from_manufacturer_data(b"\xe4/") is None
+    assert (
+        extract_serial_number_from_manufacturer_data(
+            bytearray(_manufacturer_data(3210123456))
+        )
+        == "3210123456"
+    )
 
 
 def test_parse_supported_advertisement_data_from_serial_number() -> None:
@@ -60,3 +66,70 @@ def test_parse_known_unsupported_advertisement_data_from_name() -> None:
     assert result.model is None
     assert result.serial_number is None
     assert result.known_unsupported is True
+
+
+def test_parse_supported_advertisement_data_from_unique_service_uuid() -> None:
+    """Test passive parsing can classify older devices from a unique UUID."""
+    result = parse_advertisement_data(
+        local_name=None,
+        manufacturer_data=None,
+        service_uuids=["b42e1c08-ade7-11e4-89d3-123b93f75cba"],
+    )
+
+    assert result is not None
+    assert result.model is AirthingsDeviceType.WAVE_PLUS
+    assert result.serial_number is None
+    assert result.known_unsupported is False
+
+
+def test_parse_advertisement_data_returns_serial_only_for_unknown_serial() -> None:
+    """Test passive parsing keeps the serial when the type is still unknown."""
+    result = parse_advertisement_data(
+        local_name=None,
+        manufacturer_data=_manufacturer_data(3990123456),
+        service_uuids=None,
+    )
+
+    assert result is not None
+    assert result.model is None
+    assert result.serial_number == "3990123456"
+    assert result.known_unsupported is False
+
+
+def test_parse_advertisement_data_unique_uuid_wins_for_unknown_serial() -> None:
+    """Test a unique legacy UUID still identifies the device model."""
+    result = parse_advertisement_data(
+        local_name=None,
+        manufacturer_data=_manufacturer_data(3990123456),
+        service_uuids=["b42e3882-ade7-11e4-89d3-123b93f75cba"],
+    )
+
+    assert result is not None
+    assert result.model is AirthingsDeviceType.WAVE_MINI
+    assert result.serial_number == "3990123456"
+    assert result.known_unsupported is False
+
+
+def test_parse_advertisement_data_returns_none_for_ambiguous_service_uuids() -> None:
+    """Test passive parsing does not guess when multiple unique UUIDs conflict."""
+    result = parse_advertisement_data(
+        local_name=None,
+        manufacturer_data=None,
+        service_uuids=[
+            "b42e1c08-ade7-11e4-89d3-123b93f75cba",
+            "b42e3882-ade7-11e4-89d3-123b93f75cba",
+        ],
+    )
+
+    assert result is None
+
+
+def test_parse_advertisement_data_returns_none_without_identifiers() -> None:
+    """Test passive parsing returns None when the advertisement has no signals."""
+    result = parse_advertisement_data(
+        local_name=None,
+        manufacturer_data=None,
+        service_uuids=None,
+    )
+
+    assert result is None

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -8,7 +8,7 @@ from airthings_ble import (
 
 def _manufacturer_data(serial_number: int) -> bytes:
     """Build advertisement manufacturer data with an Airthings serial number."""
-    return b"\xe4/" + serial_number.to_bytes(4, "little")
+    return serial_number.to_bytes(4, "little") + b"\x00\x00"
 
 
 def test_extract_serial_number_from_manufacturer_data() -> None:
@@ -17,7 +17,7 @@ def test_extract_serial_number_from_manufacturer_data() -> None:
         extract_serial_number_from_manufacturer_data(_manufacturer_data(2930123456))
         == "2930123456"
     )
-    assert extract_serial_number_from_manufacturer_data(b"\xe4/") is None
+    assert extract_serial_number_from_manufacturer_data(b"\xe4/\x00") is None
     assert (
         extract_serial_number_from_manufacturer_data(
             bytearray(_manufacturer_data(3210123456))
@@ -51,7 +51,27 @@ def test_parse_known_unsupported_advertisement_data_from_serial_number() -> None
     assert result is not None
     assert result.model is None
     assert result.serial_number == "2960123456"
+    assert result.model_code == "2960"
+    assert result.unsupported_name == "View Plus"
     assert result.known_unsupported is True
+    assert result.unknown is False
+
+
+def test_parse_known_unsupported_hub_advertisement_data_from_serial_number() -> None:
+    """Test passive parsing rejects hub devices from serial range."""
+    result = parse_advertisement_data(
+        local_name="Generic Airthings",
+        manufacturer_data=_manufacturer_data(2810123456),
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is None
+    assert result.serial_number == "2810123456"
+    assert result.model_code == "2810"
+    assert result.unsupported_name == "Hub"
+    assert result.known_unsupported is True
+    assert result.unknown is False
 
 
 def test_parse_known_unsupported_advertisement_data_from_name() -> None:
@@ -65,7 +85,61 @@ def test_parse_known_unsupported_advertisement_data_from_name() -> None:
     assert result is not None
     assert result.model is None
     assert result.serial_number is None
+    assert result.model_code is None
+    assert result.unsupported_name == "Airthings View Plus"
     assert result.known_unsupported is True
+    assert result.unknown is False
+
+
+def test_parse_advertisement_data_ignores_non_serial_manufacturer_payload() -> None:
+    """Test shared UUID devices are not rejected on non-serial payloads."""
+    result = parse_advertisement_data(
+        local_name="Corentium Home 2",
+        manufacturer_data=bytes.fromhex("c6 15 b7 c1 00 00"),
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is AirthingsDeviceType.CORENTIUM_HOME_2
+    assert result.serial_number == "3250001350"
+    assert result.model_code == "3250"
+    assert result.unsupported_name is None
+    assert result.known_unsupported is False
+    assert result.unknown is False
+
+
+def test_parse_advertisement_data_identifies_tern_from_serial_number() -> None:
+    """Test shared UUID devices use the serial prefix instead of the local name."""
+    result = parse_advertisement_data(
+        local_name="Airthings Tern CO2",
+        manufacturer_data=bytes.fromhex("e0 cb 54 bf 00 00"),
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is AirthingsDeviceType.WAVE_ENHANCE_EU
+    assert result.serial_number == "3210005472"
+    assert result.model_code == "3210"
+    assert result.unsupported_name is None
+    assert result.known_unsupported is False
+    assert result.unknown is False
+
+
+def test_parse_advertisement_data_marks_unknown_for_b2b_serials() -> None:
+    """Test unsupported tern-family serial ranges stay unknown."""
+    result = parse_advertisement_data(
+        local_name="Airthings Tern CO2",
+        manufacturer_data=_manufacturer_data(3110002645),
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is None
+    assert result.serial_number == "3110002645"
+    assert result.model_code == "3110"
+    assert result.unsupported_name is None
+    assert result.known_unsupported is False
+    assert result.unknown is True
 
 
 def test_parse_supported_advertisement_data_from_unique_service_uuid() -> None:
@@ -79,7 +153,10 @@ def test_parse_supported_advertisement_data_from_unique_service_uuid() -> None:
     assert result is not None
     assert result.model is AirthingsDeviceType.WAVE_PLUS
     assert result.serial_number is None
+    assert result.model_code is None
+    assert result.unsupported_name is None
     assert result.known_unsupported is False
+    assert result.unknown is False
 
 
 def test_parse_advertisement_data_returns_serial_only_for_unknown_serial() -> None:
@@ -93,7 +170,10 @@ def test_parse_advertisement_data_returns_serial_only_for_unknown_serial() -> No
     assert result is not None
     assert result.model is None
     assert result.serial_number == "3990123456"
+    assert result.model_code == "3990"
+    assert result.unsupported_name is None
     assert result.known_unsupported is False
+    assert result.unknown is True
 
 
 def test_parse_advertisement_data_unique_uuid_wins_for_unknown_serial() -> None:
@@ -107,7 +187,10 @@ def test_parse_advertisement_data_unique_uuid_wins_for_unknown_serial() -> None:
     assert result is not None
     assert result.model is AirthingsDeviceType.WAVE_MINI
     assert result.serial_number == "3990123456"
+    assert result.model_code == "3990"
+    assert result.unsupported_name is None
     assert result.known_unsupported is False
+    assert result.unknown is False
 
 
 def test_parse_advertisement_data_returns_none_for_ambiguous_service_uuids() -> None:

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -1,0 +1,62 @@
+from airthings_ble import (
+    AIRTHINGS_SHARED_SERVICE_UUID,
+    AirthingsDeviceType,
+    extract_serial_number_from_manufacturer_data,
+    parse_advertisement_data,
+)
+
+
+def _manufacturer_data(serial_number: int) -> bytes:
+    """Build advertisement manufacturer data with an Airthings serial number."""
+    return b"\xe4/" + serial_number.to_bytes(4, "little")
+
+
+def test_extract_serial_number_from_manufacturer_data() -> None:
+    """Test serial number extraction from manufacturer data."""
+    assert (
+        extract_serial_number_from_manufacturer_data(_manufacturer_data(2930123456))
+        == "2930123456"
+    )
+    assert extract_serial_number_from_manufacturer_data(b"\xe4/") is None
+
+
+def test_parse_supported_advertisement_data_from_serial_number() -> None:
+    """Test passive parsing of a supported advertisement."""
+    result = parse_advertisement_data(
+        local_name="Generic Airthings",
+        manufacturer_data=_manufacturer_data(3210123456),
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is AirthingsDeviceType.WAVE_ENHANCE_EU
+    assert result.serial_number == "3210123456"
+    assert result.known_unsupported is False
+
+
+def test_parse_known_unsupported_advertisement_data_from_serial_number() -> None:
+    """Test passive parsing rejects unsupported devices from serial range."""
+    result = parse_advertisement_data(
+        local_name="Generic Airthings",
+        manufacturer_data=_manufacturer_data(2960123456),
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is None
+    assert result.serial_number == "2960123456"
+    assert result.known_unsupported is True
+
+
+def test_parse_known_unsupported_advertisement_data_from_name() -> None:
+    """Test passive parsing rejects unsupported devices from the local name."""
+    result = parse_advertisement_data(
+        local_name="Airthings View Plus",
+        manufacturer_data=None,
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is None
+    assert result.serial_number is None
+    assert result.known_unsupported is True

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -26,6 +26,17 @@ def test_extract_serial_number_from_manufacturer_data() -> None:
     )
 
 
+def test_parse_advertisement_data_ignores_invalid_serial_shape() -> None:
+    """Test payloads that decode but do not look like Airthings serials are ignored."""
+    result = parse_advertisement_data(
+        local_name=None,
+        manufacturer_data=b"\x01\x02\x03\x04\x00\x00",
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is None
+
+
 def test_parse_supported_advertisement_data_from_serial_number() -> None:
     """Test passive parsing of a supported advertisement."""
     result = parse_advertisement_data(
@@ -87,6 +98,23 @@ def test_parse_known_unsupported_advertisement_data_from_name() -> None:
     assert result.serial_number is None
     assert result.model_code is None
     assert result.unsupported_name == "Airthings View Plus"
+    assert result.known_unsupported is True
+    assert result.unknown is False
+
+
+def test_parse_known_unsupported_advertisement_data_from_name_with_bad_serial() -> None:
+    """Test unsupported-name fallback keeps no model code for invalid serials."""
+    result = parse_advertisement_data(
+        local_name="Renew AP-1",
+        manufacturer_data=b"\x01\x02\x03\x04\x00\x00",
+        service_uuids=[AIRTHINGS_SHARED_SERVICE_UUID],
+    )
+
+    assert result is not None
+    assert result.model is None
+    assert result.serial_number is None
+    assert result.model_code is None
+    assert result.unsupported_name == "Renew AP-1"
     assert result.known_unsupported is True
     assert result.unknown is False
 

--- a/tests/test_device_type.py
+++ b/tests/test_device_type.py
@@ -19,23 +19,41 @@ def test_device_type() -> None:
     with pytest.raises(ValueError):
         AirthingsDeviceType("1234")
 
-    assert AirthingsDeviceType.from_raw_value("2900") == AirthingsDeviceType.WAVE_GEN_1
-    assert AirthingsDeviceType.from_raw_value("2920") == AirthingsDeviceType.WAVE_MINI
-    assert AirthingsDeviceType.from_raw_value("2930") == AirthingsDeviceType.WAVE_PLUS
-    assert AirthingsDeviceType.from_raw_value("2950") == AirthingsDeviceType.WAVE_RADON
+    assert AirthingsDeviceType.from_model_code("2900") == AirthingsDeviceType.WAVE_GEN_1
+    assert AirthingsDeviceType.from_model_code("2920") == AirthingsDeviceType.WAVE_MINI
+    assert AirthingsDeviceType.from_model_code("2930") == AirthingsDeviceType.WAVE_PLUS
+    assert AirthingsDeviceType.from_model_code("2950") == AirthingsDeviceType.WAVE_RADON
     assert (
-        AirthingsDeviceType.from_raw_value("3210")
+        AirthingsDeviceType.from_model_code("3210")
         == AirthingsDeviceType.WAVE_ENHANCE_EU
     )
     assert (
-        AirthingsDeviceType.from_raw_value("3220")
+        AirthingsDeviceType.from_model_code("3220")
         == AirthingsDeviceType.WAVE_ENHANCE_US
     )
+    assert AirthingsDeviceType.from_model_code("1234") is None
 
-    unknown_device = AirthingsDeviceType.from_raw_value("1234")
-    assert unknown_device == AirthingsDeviceType.UNKNOWN
-    assert unknown_device.product_name == "Unknown"
-    assert unknown_device.raw_value == "1234"
+
+def test_device_type_from_serial_number() -> None:
+    """Test supported device families can be resolved from serial number ranges."""
+    assert (
+        AirthingsDeviceType.from_serial_number("2900123456")
+        == AirthingsDeviceType.WAVE_GEN_1
+    )
+    assert (
+        AirthingsDeviceType.from_serial_number("3210005838")
+        == AirthingsDeviceType.WAVE_ENHANCE_EU
+    )
+    assert (
+        AirthingsDeviceType.from_serial_number("3220001234")
+        == AirthingsDeviceType.WAVE_ENHANCE_US
+    )
+    assert (
+        AirthingsDeviceType.from_serial_number("3250001350")
+        == AirthingsDeviceType.CORENTIUM_HOME_2
+    )
+    assert AirthingsDeviceType.from_serial_number("3110002645") is None
+    assert AirthingsDeviceType.from_serial_number("3990123456") is None
 
 
 def test_battery_calculation() -> None:


### PR DESCRIPTION
This PR improves passive advertisement handling consumers can classify Airthings devices before opening a BLE connection.

It adds advertisement parsing for supported devices, identifies known unsupported families like View and Renew, and treats unknown Airthings-like devices separately instead of exposing them as generic unknown BLE devices.

It also exposes the shared Airthings service UUID constants publicly and cleans up device model handling by removing the UNKNOWN device type.